### PR TITLE
Add extension to extension page

### DIFF
--- a/src/lib/libraries/extensions/index.jsx
+++ b/src/lib/libraries/extensions/index.jsx
@@ -317,5 +317,10 @@ export default [
             />
         ),
         helpLink: 'https://scratch.mit.edu/vernier'
+    },
+    {
+        name: 'Go Direct Force & Acceleration',
+        extensionId: 'pedaloBlocks',
+        featured: true
     }
 ];


### PR DESCRIPTION
This PR should include the extension in the extension page, where it can be loaded to scratch itself.
